### PR TITLE
Only show keywords if there is at least one set

### DIFF
--- a/template.typ
+++ b/template.typ
@@ -189,7 +189,10 @@
       #set align(left)  
       *Abstract.* #abstract
       #v(3.5mm)
-      *Keywords:* #keywords.join([ $dot$ ])
+			#if keywords.len() > 0 {
+        let display = if type(keywords) == str { keywords } else { keywords.join([ $dot$ ]) }
+        text[*Keywords:* #display]
+      }
     ]
     
 


### PR DESCRIPTION
Hi there,

first of all, thanks for the template! Saved me a good few hours of work :D
I added a small tweak to only show the keywords if at least one is set. Before, the `Keywords: ` would always be shown, even if nothing follows it.

See the screenshot: 
<img width="329" alt="image" src="https://github.com/Jozott00/typst-LLNCS-template/assets/40794797/ccd189e0-019f-42e6-a80b-5a975d8f877b">

The if statement is to handle the case of only one keyword being set, where the variable gets turned into a `str`, and compilation fails as the `.join()` function does not exist for `str`.