### PR TITLE
add spacing between section number and the title

### DIFF
--- a/template.typ
+++ b/template.typ
@@ -83,6 +83,7 @@
 
   //// HEADING CONFIGS
   set heading(numbering: "1.1")
+  show heading: it => if it.numbering == none { it } else { block(counter(heading).display(it.numbering) + h(1em) + it.body) }
   // padding
   show heading.where(level: 1): pad.with(bottom: 0.64em, top: 0.64em)
   show heading.where(level: 2): pad.with(bottom: 0.9em)


### PR DESCRIPTION
The original spacing between the section number and title is too small compared to the llncs template. Add some spacing in between.