### PR TITLE
fix the theorem name font and alignment

### DIFF
--- a/template/theorem_proof_cnf.typ
+++ b/template/theorem_proof_cnf.typ
@@ -9,12 +9,13 @@
   number,
   body
 ) = block(width: 100%, breakable: true)[#{
+  set align(left)
   strong(thm-type) + " "
   if number != none {
     strong(number) + ". "
   }
   if name != none {
-    emph[(#name)] + " "
+    [*(#name).*] + " "
   }
   emph(body)
   v(5pt)


### PR DESCRIPTION
Change the name of theorem to bf and fix the alignment of the theorem (same as for the proof)