### PR TITLE
Updated Template to hide the Abstract if it's empty

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -217,7 +217,9 @@
       #set align(left)
       #set par(justify: true)
       #set text(size: 9pt)
-      *Abstract.* #abstract
+      #if abstract != [] [
+        *Abstract.* #abstract
+      ]
       #if keywords.len() > 0 {
         v(4.5mm)
         let display = if type(keywords) == str { keywords } else { keywords.join([ $dot$ ]) }

--- a/typst.toml
+++ b/typst.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fine-lncs"
-version = "0.2.0"
+version = "0.3.0"
 entrypoint = "src/lib.typ"
 authors = ["jozott"]
 license = "MIT"


### PR DESCRIPTION
This PR removes the abstract block if the abstract field is empty