### PR TITLE
ft: Add running title option for long paper titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
 
 #show: lncs.with(
   title: "Contribution Title",
+  // Opt.: If title is longer than 60 characters
+  // running_title: [Running Title],
   thanks: "Supported by organization x.",
   authors: (
     author("First Author", 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@
 
 #show: lncs.with(
   title: "Contribution Title",
-  // Opt.: If title is longer than 60 characters
-  // running_title: [Running Title],
+  // Opt.: Set this, if the title is too long to avoid linebreaks in the header of odd pages
+  // running_title: "Short version of contribution title"
   thanks: "Supported by organization x.",
   authors: (
     author("First Author", 

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -24,6 +24,8 @@
 // Go ahead and customize it to your liking!
 #let lncs(
   title: [Contribution Title],
+  // Opt.: If title is longer than 60 characters
+  running_title: [Running Title],
   thanks: none,
   abstract: [],
   authors: (),
@@ -70,7 +72,11 @@
 
       if (calc.rem(pagenumer, 2) == 1) {
         align(right)[
-          #title
+          #if title.len() > 60 [
+            #running_title
+          ] else [
+            #title
+          ]
           #h(1cm)
           #counter(page).display()
         ]

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -24,8 +24,8 @@
 // Go ahead and customize it to your liking!
 #let lncs(
   title: [Contribution Title],
-  // Opt.: If title is longer than 60 characters
-  running_title: [Running Title],
+  // Opt.: Set this, if the title is too long to avoid linebreaks in the header of odd pages
+  running_title: none,
   thanks: none,
   abstract: [],
   authors: (),
@@ -72,7 +72,7 @@
 
       if (calc.rem(pagenumer, 2) == 1) {
         align(right)[
-          #if title.len() > 60 [
+          #if running_title != none [
             #running_title
           ] else [
             #title

--- a/template/main.typ
+++ b/template/main.typ
@@ -16,8 +16,8 @@
 
 #show: lncs.with(
   title: "Contribution Title",
-  // Opt.: If title is longer than 60 characters
-  // running_title: "Running title"
+  // Opt.: Set this, if the title is too long to avoid linebreaks in the header of odd pages
+  // running_title: "Short version of contribution title"
   thanks: "Supported by organization x.",
   authors: (
     author("First Author", 

--- a/template/main.typ
+++ b/template/main.typ
@@ -16,6 +16,8 @@
 
 #show: lncs.with(
   title: "Contribution Title",
+  // Opt.: If title is longer than 60 characters
+  // running_title: "Running title"
   thanks: "Supported by organization x.",
   authors: (
     author("First Author", 


### PR DESCRIPTION
Problem:
The official LNCS template from Overleaf [1] features a \running_title macro, which is used if the contribution title is too long.
This Typst template instead overflows into a second row.  

Solution:
This PR adds an optional flag to set a `running_title`, which is used if the contribution title is longer than 60 characters.
Around 60 characters is the limit to not overflow into a second row.

[1] https://www.overleaf.com/latex/templates/springer-lecture-notes-in-computer-science/kzwwpvhwnvfj#.WuA4JS5uZpi