### PR TITLE
ft: Allow figure abbreviation in different languages

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -142,7 +142,7 @@
 
     if it.func() == figure and it.kind == image {
       supplement = it.supplement
-    } else if it.func() == ref and it.element != none {
+    } else if it.func() == ref and it.element.func() == figure {
       supplement = it.element.supplement
     } else {
       return it

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -279,7 +279,7 @@
 
   // Style bibliography.
   show std.bibliography: set text(9pt)
-  set std.bibliography(title: text(12pt)[References], style: "springer-lecture-notes-in-computer-science")
+  set std.bibliography(style: "springer-lecture-notes-in-computer-science")
 
   // Display bibliography.
   bibliography

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -33,6 +33,7 @@
   // The result of a call to the `bibliography` function or `none`.
   bibliography: none,
   page-config: (:),
+  lang: "en",
   body,
 ) = {
   //// CONSTANTS
@@ -42,7 +43,7 @@
 
   // Set the document's basic properties.
   set document(author: authors.map(a => a.name), title: title)
-  set text(font: "New Computer Modern", lang: "en", size: 10pt)
+  set text(font: "New Computer Modern", lang: lang, size: 10pt)
 
 
   //// EVALUATIONS
@@ -134,13 +135,29 @@
   show figure: pad.with(top: 20.5pt, bottom: 22pt)
   show figure: set text(9pt)
   show figure: align.with(left)
+
   // let Figure display as Fig
-  let fig_replace(it) = {
-    show "Figure": "Fig."
+  let supplement_replace(it) = {
+    let supplement
+
+    if it.func() == figure and it.kind == image {
+      supplement = it.supplement
+    } else if it.func() == ref and it.element != none {
+      supplement = it.element.supplement
+    } else {
+      return it
+    }
+    supplement = supplement.text
+
+    if supplement.len() <= 3 {
+      return it
+    }
+
+    show supplement: supplement.slice(0, 3) + "."
     it
   }
-  show figure.where(kind: image): fig_replace
-  show ref: fig_replace
+  show figure.where(kind: image): supplement_replace
+  show ref: supplement_replace
 
   //// TABLE CONFIG
   let table_stroke = 0.5pt

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -142,7 +142,7 @@
 
     if it.func() == figure and it.kind == image {
       supplement = it.supplement
-    } else if it.func() == ref and it.element.func() == figure {
+    } else if it.func() == ref and it.element != none and it.element.func() == figure {
       supplement = it.element.supplement
     } else {
       return it


### PR DESCRIPTION
Problems:
1. The language is "en" which causes the e.g. index to be named "Index" automatically.
2. By changing the language, figure supplements also change and the previous replacement method fails.

Solutions:
1. Defaulting to "en" as the document language while allowing other languages to be set.
2. Instead of replacing the string literal "Figure", replace the language default for the figure supplement by its first three characters followed by a dot
