### PR TITLE
ft: Add running author option to override default shortening

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@
 #show: lncs.with(
   title: "Contribution Title",
   // Opt.: Set this, if the title is too long to avoid linebreaks in the header of odd pages
-  // running-title: "Short version of contribution title"
+  // running-title: "Short version of contribution title",
+  // running-author: "Override the default author shortening",
   thanks: "Supported by organization x.",
   authors: (
     author("First Author", insts: (inst_princ), oicd: "0000-1111-2222-3333"),

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -26,6 +26,7 @@
   title: [Contribution Title],
   // Opt.: Set this, if the title is too long to avoid linebreaks in the header of odd pages
   running-title: none,
+  running-author: none,
   thanks: none,
   abstract: [],
   authors: (),
@@ -89,7 +90,11 @@
         align(left)[
           #counter(page).display()
           #h(1cm)
-          #author_running
+          #if running-author != none [
+            #running-author
+          ] else [
+            #author_running
+          ]
         ]
       }
     },

--- a/template/main.typ
+++ b/template/main.typ
@@ -20,7 +20,8 @@
 #show: lncs.with(
   title: "Contribution Title",
   // Opt.: Set this, if the title is too long to avoid linebreaks in the header of odd pages
-  // running-title: "Short version of contribution title"
+  // running-title: "Short version of contribution title",
+  // running-author: "Override the default author shortening",
   thanks: "Supported by organization x.",
   authors: (
     author("First Author", insts: (inst_princ), oicd: "0000-1111-2222-3333"),

--- a/tests/readme/test.typ
+++ b/tests/readme/test.typ
@@ -19,7 +19,8 @@
 #show: lncs.with(
   title: "Contribution Title",
   // Opt.: Set this, if the title is too long to avoid linebreaks in the header of odd pages
-  // running-title: "Short version of contribution title"
+  // running-title: "Short version of contribution title",
+  // running-author: "Override the default author shortening",
   thanks: "Supported by organization x.",
   authors: (
     author("First Author", insts: (inst_princ), oicd: "0000-1111-2222-3333"),

--- a/tests/template/test.typ
+++ b/tests/template/test.typ
@@ -20,7 +20,8 @@
 #show: lncs.with(
   title: "Contribution Title",
   // Opt.: Set this, if the title is too long to avoid linebreaks in the header of odd pages
-  // running-title: "Short version of contribution title"
+  // running-title: "Short version of contribution title",
+  // running-author: "Override the default author shortening",
   thanks: "Supported by organization x.",
   authors: (
     author("First Author", insts: (inst_princ), oicd: "0000-1111-2222-3333"),


### PR DESCRIPTION
There is currently no way to override the shortening of author names in the page headers which was available in LLCNS via `\authorrunning{}`. This PR adds an optional `running-author` flag similar to the existing `running-title`.