### PR TITLE
fix: allow author name with dashes

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -51,7 +51,7 @@
   let author_running = {
     let an = authors.map(it => {
       let ns = it.name.split(" ")
-      [#ns.at(0).at(0). #ns.last()]
+      [#ns.at(0).split("-").map(w => w.at(0) + ".").join("-") #ns.last()]
     })
     if an.len() < 2 {
       an.join(", ")

--- a/template/main.typ
+++ b/template/main.typ
@@ -24,7 +24,11 @@
   // running-author: "Override the default author shortening",
   thanks: "Supported by organization x.",
   authors: (
-    author("First-Name Author", insts: (inst_princ), oicd: "0000-1111-2222-3333"),
+    author(
+      "First-Name Author",
+      insts: (inst_princ),
+      oicd: "0000-1111-2222-3333",
+    ),
     author(
       "Second Author",
       insts: (inst_springer, inst_abc),

--- a/template/main.typ
+++ b/template/main.typ
@@ -24,7 +24,7 @@
   // running-author: "Override the default author shortening",
   thanks: "Supported by organization x.",
   authors: (
-    author("First Author", insts: (inst_princ), oicd: "0000-1111-2222-3333"),
+    author("First-Name Author", insts: (inst_princ), oicd: "0000-1111-2222-3333"),
     author(
       "Second Author",
       insts: (inst_springer, inst_abc),

--- a/tests/template/test.typ
+++ b/tests/template/test.typ
@@ -24,7 +24,11 @@
   // running-author: "Override the default author shortening",
   thanks: "Supported by organization x.",
   authors: (
-    author("First-Name Author", insts: (inst_princ), oicd: "0000-1111-2222-3333"),
+    author(
+      "First-Name Author",
+      insts: (inst_princ),
+      oicd: "0000-1111-2222-3333",
+    ),
     author(
       "Second Author",
       insts: (inst_springer, inst_abc),

--- a/tests/template/test.typ
+++ b/tests/template/test.typ
@@ -24,7 +24,7 @@
   // running-author: "Override the default author shortening",
   thanks: "Supported by organization x.",
   authors: (
-    author("First Author", insts: (inst_princ), oicd: "0000-1111-2222-3333"),
+    author("First-Name Author", insts: (inst_princ), oicd: "0000-1111-2222-3333"),
     author(
       "Second Author",
       insts: (inst_springer, inst_abc),


### PR DESCRIPTION
Author names such as "Jean-Pierre Dupont" now abbrieviates correctly as "J.-P. Dupont" rather than "J. Dupont".